### PR TITLE
Use mocks in unit testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,104 @@
 # actions-mocks
-Mocking helpers to use when end-to-end testing GitHub Actions
+Mocking helpers for testing GitHub Actions
 
 ## Usage
 
-There is one exported method, `run(action, { mocks, env })`
+The exported package contains the following GitHub Actions testing utilities.
+```javascript
+{
+  // used to end-to-end test an action script
+  run: [AsyncFunction: run],
+
+  // used to unit test an action
+  mocks: {
+    exec: {
+      mock: [Function: mock],
+      clear: [Function: clear],
+      restore: [Function: restore],
+      setLog: [Function: setLog]
+    },
+    github: {
+      mock: [Function: mock],
+      clear: [Function: clear],
+      restore: [Function: restore],
+      setLog: [Function: setLog]
+    }
+  }
+}
+```
+
+### End to end testing
+
+Use the exported method, `run(action, { mocks, env })`
 - `action` (required) is the full path to the action script to run
 - `mocks` (optional) configurations for mocking `@actions` modules
 - `env` (optional) environment to set on action process
 
-All mocks are enabled by default to provide a safe environment to run actions locally.  They can be configured by setting `mocks.<actions toolkit package name> = [<mock expectations>]`. All mock expectations MUST be serializable using `JSON.stringify`.
+All mock classes are enabled by default to provide a safe environment to run actions locally.  Mock classes can be configured by setting `mocks.<actions toolkit package name> = [<mock expectations>]`. All mock expectations MUST be serializable using `JSON.stringify`.
 
-e.g. `mocks.exec = [{ command: 'git commit', exitCode: 1 }]`
+```javascript
+mocks.exec = [{ command: 'git commit', exitCode: 1 }]
+mocks.github = [{ method: 'GET', uri: '/issues', response: 200 }]
+```
 
 `run` returns an object `{ out, err, status }`.
 - `out`: the full log of output written to `stdout`
 - `err`: the full log of output written to `stderr`
 - `status`: the exit code of the action
 
-The majority of the content in the
+See the [tests](./test/runner.test.js) for more examples.
 
-See the [tests](./test/index.test.js) for more examples.
+### Unit testing
 
-### Mocking `@actions/exec`
+This package can be used for unit testing with the imported `mocks` object.
 
-The `@actions/exec` mock catches all calls to `@actions/exec.exec`, logs the full command and it's execution options to `stdout`, and returns an exit code.  Any calls that don't match any configuration entries from `mocks.exec` will return 127 by default.
+Each `mocks` sub-object supports the following API:
 
-Calls are logged as `<full command with args> <key>:<value> <key>:<value>` where key/value pairs are from the `options` object passed to `@actions/exec.exec`.
+`mock` - Add one or more mock(s).  Accepts either a single mock configuration and an array of mock configurations.
+   - defaults to `JSON.parse(process.env.<MOCK NAME>_MOCKS || '[]')`
+`setLog` - Set the method used to log commands and API calls during testing
+   - defaults to `console.log`
+`clear` - Clears all currently configured mocks
+`restore` - Resets configured mocks and the logging method back to their defaults.
+
+```javascript
+const { mocks } = require('actions-mocks');
+const myLib = require('../lib/myLib');
+const os = require('os');
+
+// myLib.gitAdd calls `git add`
+let output = '';
+mocks.exec.setLog(log => output += log + os.EOL);
+mocks.exec.mock({ command: 'git add', stdout: 'git output', exitCode: 10 });
+
+const { exitCode, commandStdout } = await myLib.gitAdd('arg');
+expect(exitCode).toEqual(10);
+expect(commandStdout).toMatch('git output');
+expect(output).toMatch('git add');
+
+// myLib.listIssues calls `octokit.issues.list()`
+output = '';
+mocks.github.setLog(log => output += log + os.EOL);
+mocks.github.mock({ method: 'GET', uri: '/issues', response: '[]', responseCode: 200 });
+
+const { data, status } = await myLib.listIssues();
+expect(status).toEqual(200);
+expect(data).toEqual([]);
+expect(output).toMatch('GET /issues');
+```
+
+See the [exec](./test/mocks/exec.test.js) and [github](./test/mocks/github.test.js) unit tests for more examples.
+
+## Mocking `@actions/exec`
+
+The `@actions/exec` mock catches all calls to `@actions/exec.exec` and
+1. log the full command and it's execution options to the specified logging method (default: `console.log`)
+   - calls are logged as `<full command with args> <key>:<value> <key>:<value>` where key/value pairs are from the `options` object passed to `@actions/exec.exec`
+2. output provided `stdout` using the passed in options
+3. output provided `stderr` using the passed in options
+4. return an exit code
+   - if the command doesn't match a configured mock, returns 127
+   - if the command matches a configured mock, returns the configured `exitCode` or 0 if not set
 
 The mocked call returns a promise that is resolved for a 0 exit code and rejected for all other exit codes.  Calls to `@actions/exec.exec` that specify `options: { ignoreReturnCode: true }` will never be rejected.
 
@@ -45,9 +118,15 @@ To configure the mock behavior, pass an array of objects with the following form
 {
   // (required) pattern of command to match.
   // Uses String.prototype.match to perform regex evaluation
-  command: ''
-  // (optional) exit code to return, defaults to 127
-  exitCode: 0
+  command: '',
+  // (optional) data to output to stdout on matching exec call
+  stdout: '',
+  // (optional) data to output to stderr on matching exec call
+  stderr: '',
+  // (optional) exit code to return, defaults to 0
+  exitCode: 0,
+  // (optional) number of times the mock should be used.  defaults to a persistent mock if not set
+  count: 1
 }
 ```
 
@@ -58,13 +137,18 @@ Command patterns are prioritized based on their location in the passed in array.
 { command: '', exitCode: 0 }
 ```
 
-### Mocking `@actions/github`
+## Mocking `@actions/github`
 
-The `@actions/github` mock uses `nock` to catch all calls to `https://api.github.com`.  The mock logs all API requests to `stdout` and returns a response.  Any API calls that don't match any configuration entries from `mocks.github` will return a `404` code by default.
-
-Calls are logged as `<method (uppercase)> <path?query> <request body>`.
-
-By default, any API calls using an octokit/rest.js instance return from `new @actions/github.GitHub` that doesn't match specified configuration will return a 404 response.
+The `@actions/github` mock uses `nock` to catch all calls to `https://api.github.com` and
+1. log all API requests to the specified logging method (default: `console.log`)
+   - calls are logged as `<METHOD> <path?query> <request body>`
+2. returns a response
+   1. status
+      - calls that don't match any configured mocks will return a `404`
+      - calls that match a configured mock will return `responseCode`, or `200` if not set
+   2. data
+      - response data can be specified when configuring a mock using the `response` property
+      - response data can be loaded from a fixture by using the `responseFixture` property
 
 ```javascript
 // with a successful (2xx) mocked API call
@@ -82,18 +166,22 @@ To configure the mock behavior, pass an array of objects with the following form
   // (required) uri pattern to match.  should not include the domain (https://api.github.com)
   // Uses String.prototype.match to perform regex evaluation
   uri: '/user/repos',
-  // (required) http code to set on the response
+  // (optional) http code to set on the response, default: 200
   responseCode: 200,
   // (optional) response to send, given as a string
-  response: '[]'
+  response: '[]',
   // (optional) response to send, given as a path to a JSON fixture to load
-  responseFixture: ''
+  responseFixture: '',
+  // (optional) number of times the mock should be used.  defaults to a persistent mock if not set
+  count: 1
 }
 ```
 
-Command patterns are prioritized based on their location in the passed in array.  In the following example, `GET /user/repos` will return a 400 while all other `GET` commands will return 500.
+Command patterns are prioritized based on their location in the passed in array.
 
 ```javascript
+// `GET /user/repos` will return a 400
 { method: 'GET', uri: '/user/repos', responseCode: 400 },
+// all other `GET` commands will return 500
 { method: 'GET', uri: '', responseCode: 500 }
 ```

--- a/index.js
+++ b/index.js
@@ -1,53 +1,7 @@
-const { exec } = require('@actions/exec');
-const fs = require('fs').promises;
-const os = require('os');
-const path = require('path');
-const stream = require('stream');
-
-const mocksDir = path.join(__dirname, 'lib', 'mocks');
-const nodeArgs = [];
-async function loadMocks() {
-  if (nodeArgs.length == 0) {
-    nodeArgs.push(
-      // always run the loader first
-      path.join(__dirname, 'lib', 'loader'),
-      ...(await fs.readdir(mocksDir)).map(file => path.join(mocksDir, file))
-    );
-  }
-}
-
-async function run(action, { mocks = {}, env = {} } = {}) {
-  const options = {
-    env: {
-      ...process.env, // send process.env to action under test
-      ...env // any passed in env overwrites process.env
-    }
-  };
-
-  if (mocks) {
-    // send mocks configs to the child process
-    // mocks keys should match actions toolkit package names, i.e. `exec` or `github`
-    for(let key in mocks) {
-      // send the mock options to the child process through ENV
-      options.env[`${key.toUpperCase()}_MOCKS`] = JSON.stringify(mocks[key]);
-    }
-  }
-
-  let outString = '';
-  let errString = '';
-  options.ignoreReturnCode = true;
-  options.listeners = {
-    stdout: data => outString += data.toString() + os.EOL,
-    stderr: data => errString += data.toString() + os.EOL
-  };
-  options.outStream = new stream.Writable({ write: data => outString += data + os.EOL });
-  options.errStream = new stream.Writable({ write: data => errString += data + os.EOL });
-
-  await loadMocks();
-  const exitCode = await exec('node', [...nodeArgs, action], options);
-  return { out: outString, err: errString, status: exitCode };
-}
-
 module.exports = {
-  run
-}
+  run: require('./lib/runner'),
+  mocks: {
+    exec: require('./lib/mocks/exec'),
+    github: require('./lib/mocks/github')
+  }
+};

--- a/lib/mocks/exec.js
+++ b/lib/mocks/exec.js
@@ -1,26 +1,90 @@
 const exec = require('@actions/exec');
-const sinon = require('sinon');
+const os = require('os');
+const sinon = require('sinon').createSandbox();
 
-const execMocks = JSON.parse(process.env.EXEC_MOCKS || '[]');
-sinon.stub(exec, 'exec').callsFake((command, args, options) => {
-  args = args || [];
-  options = options || {};
+const mocks = [];
+let logMethod;
 
-  // log the full command and options to be verified by tests
-  const optionsArray = Object.keys(options).map(key => `${key}:${options[key]}`);
+function getOutputString(value) {
+  if (!value) {
+    return null;
+  } else if (Array.isArray(value)) {
+    return value.map(arg => JSON.stringify(arg)).join(os.EOL);
+  } else {
+    return JSON.stringify(value);
+  }
+}
+
+sinon.stub(exec, 'exec').callsFake(async (command, args = [], options = {}) => {
+  const optionsArray = Object.keys(options || {}).map(key => `${key}:${JSON.stringify(options[key])}`);
   const fullCommand = [command, ...args, ...optionsArray].join(' ');
-  console.log(fullCommand);
+  logMethod(fullCommand);
 
-  // try to find a mock that matches the full command
-  const mock = execMocks.find(mock => !!fullCommand.match(mock.command));
+  let exitCode = 1;
 
-  // default to 127 (error) if mock is not found
-  const exitCode = mock ? mock.exitCode : 127;
+  const mock = mocks.find(mock => !!fullCommand.match(mock.command));
+  if (mock) {
+    const stdout = getOutputString(mock.stdout);
+    if (stdout) {
+      // write to stdout using the passed in options
+      await exec.exec.wrappedMethod('node', ['-e', `process.stdout.write(${stdout})`], options);
+    }
 
-  // don't raise an error if the `ignoreReturnCode` option was specified
+    const stderr = getOutputString(mock.stderr);
+    if (stderr) {
+      // write to stderr using the passed in options
+      await exec.exec.wrappedMethod('node', ['-e', `process.stderr.write(${stderr})`], options);
+    }
+
+    if (mock.exitCode || mock.exitCode === 0) {
+      exitCode = mock.exitCode;
+    }
+
+    if (mock.count > 0) {
+      mock.count -= 1;
+      if (mock.count === 0) {
+        const index = mocks.indexOf(mock);
+        mocks.splice(index, 1);
+      }
+    }
+  }
+
   if (exitCode !== 0 && !options.ignoreReturnCode) {
     return Promise.reject(exitCode);
   }
 
   return Promise.resolve(exitCode);
 });
+
+function mock(mocksToAdd) {
+  if (Array.isArray(mocksToAdd)) {
+    mocks.unshift(...mocksToAdd)
+  } else {
+    mocks.unshift(mocksToAdd);
+  }
+}
+
+function clear() {
+  mocks.length = 0;
+}
+
+function restore() {
+  clear();
+  setLog(console.log);
+
+  // by default, add all mocks from the process environment
+  mock(JSON.parse(process.env.EXEC_MOCKS || '[]'));
+}
+
+function setLog(method) {
+  logMethod = method;
+}
+
+restore();
+
+module.exports = {
+  mock,
+  clear,
+  restore,
+  setLog
+};

--- a/lib/mocks/exec.js
+++ b/lib/mocks/exec.js
@@ -20,7 +20,7 @@ sinon.stub(exec, 'exec').callsFake(async (command, args = [], options = {}) => {
   const fullCommand = [command, ...args, ...optionsArray].join(' ');
   logMethod(fullCommand);
 
-  let exitCode = 1;
+  let exitCode = 127;
 
   const mock = mocks.find(mock => !!fullCommand.match(mock.command));
   if (mock) {
@@ -36,9 +36,7 @@ sinon.stub(exec, 'exec').callsFake(async (command, args = [], options = {}) => {
       await exec.exec.wrappedMethod('node', ['-e', `process.stderr.write(${stderr})`], options);
     }
 
-    if (mock.exitCode || mock.exitCode === 0) {
-      exitCode = mock.exitCode;
-    }
+    exitCode = mock.exitCode || 0;
 
     if (mock.count > 0) {
       mock.count -= 1;

--- a/lib/mocks/github.js
+++ b/lib/mocks/github.js
@@ -1,11 +1,13 @@
 const nock = require('nock');
 
-const apiMocks = JSON.parse(process.env.GITHUB_MOCKS || '[]');
+const mocks = [];
+let logMethod = console.log;
+
 function responseFunction(uri, requestBody) {
   // log the request to match against in tests
-  console.log(`${this.req.method} ${uri} : ${JSON.stringify(requestBody)}`);
+  logMethod(`${this.req.method} ${uri} : ${JSON.stringify(requestBody)}`);
 
-  const mock = apiMocks.find(mock => mock.method == this.req.method && uri.match(mock.uri));
+  const mock = mocks.find(mock => mock.method == this.req.method && uri.match(mock.uri));
   if (!mock) {
     // if the route wasn't mocked, return 404
     return [404, 'Route not mocked'];
@@ -19,6 +21,14 @@ function responseFunction(uri, requestBody) {
     response = require(mock.responseFixture);
   }
 
+  if (mock.count > 0) {
+    mock.count -= 1;
+    if (mock.count === 0) {
+      const index = mocks.indexOf(mock);
+      mocks.splice(index, 1);
+    }
+  }
+
   return [responseCode, response];
 }
 
@@ -30,3 +40,36 @@ nock('https://api.github.com')
   .post(/.*/).reply(responseFunction)
   .patch(/.*/).reply(responseFunction)
   .delete(/.*/).reply(responseFunction);
+
+function mock(mocksToAdd) {
+  if (Array.isArray(mocksToAdd)) {
+    mocks.unshift(...mocksToAdd)
+  } else {
+    mocks.unshift(mocksToAdd);
+  }
+}
+
+function clear() {
+  mocks.length = 0;
+}
+
+function restore() {
+  clear();
+  setLog(console.log);
+
+  // by default, add all mocks from the process environment
+  mock(JSON.parse(process.env.GITHUB_MOCKS || '[]'));
+}
+
+function setLog(method) {
+  logMethod = method;
+}
+
+restore();
+
+module.exports = {
+  mock,
+  clear,
+  restore,
+  setLog
+};

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -1,0 +1,51 @@
+const { exec } = require('@actions/exec');
+const fs = require('fs').promises;
+const os = require('os');
+const path = require('path');
+const stream = require('stream');
+
+const mocksDir = path.join(__dirname, 'mocks');
+const nodeArgs = [];
+async function loadMocks() {
+  if (nodeArgs.length == 0) {
+    nodeArgs.push(
+      // always run the loader first
+      path.join(__dirname, 'loader.js'),
+      ...(await fs.readdir(mocksDir)).map(file => path.join(mocksDir, file))
+    );
+  }
+}
+
+async function run(action, { mocks = {}, env = {} } = {}) {
+  const options = {
+    env: {
+      ...process.env, // send process.env to action under test
+      ...env // any passed in env overwrites process.env
+    }
+  };
+
+  if (mocks) {
+    // send mocks configs to the child process
+    // mocks keys should match actions toolkit package names, i.e. `exec` or `github`
+    for(let key in mocks) {
+      // send the mock options to the child process through ENV
+      options.env[`${key.toUpperCase()}_MOCKS`] = JSON.stringify(mocks[key]);
+    }
+  }
+
+  let outString = '';
+  let errString = '';
+  options.ignoreReturnCode = true;
+  options.listeners = {
+    stdout: data => outString += data.toString() + os.EOL,
+    stderr: data => errString += data.toString() + os.EOL
+  };
+  options.outStream = new stream.Writable({ write: data => outString += data + os.EOL });
+  options.errStream = new stream.Writable({ write: data => errString += data + os.EOL });
+
+  await loadMocks();
+  const exitCode = await exec('node', [...nodeArgs, action], options);
+  return { out: outString, err: errString, status: exitCode };
+}
+
+module.exports = run;

--- a/test/mocks/exec.test.js
+++ b/test/mocks/exec.test.js
@@ -49,7 +49,7 @@ it('includes process.env.EXEC_MOCKS on load', async () => {
 it('returns a failure exit code if a command isn\'t mocked', async () => {
   mocks.setLog(() => {});
   mocks.clear();
-  await expect(exec.exec('command', ['test'])).rejects.toEqual(1);
+  await expect(exec.exec('command', ['test'])).rejects.toEqual(127);
 });
 
 describe('mock', () => {

--- a/test/mocks/exec.test.js
+++ b/test/mocks/exec.test.js
@@ -1,0 +1,177 @@
+// default state of mocks when module is loaded
+process.env.EXEC_MOCKS = JSON.stringify([
+  { command: '', exitCode: 0 }
+])
+
+const exec = require('@actions/exec');
+const mocks = require('../../lib/mocks/exec');
+const sinon = require('sinon');
+const stream = require('stream');
+const os = require('os');
+
+let outString;
+
+afterEach(() => {
+  mocks.restore();
+});
+
+it('uses the first found mock', async () => {
+  mocks.setLog(() => {});
+  mocks.mock([
+    { command: '', exitCode: 2 },
+    { command: '', exitCode: 3 }
+  ]);
+
+  const exitCode = await exec.exec('command', [], { ignoreReturnCode: true });
+  expect(exitCode).toEqual(2);
+});
+
+it('logs the mocked command', async () => {
+  outString = '';
+  mocks.setLog(data => outString += data);
+
+  await exec.exec('command', ['test', 'args']);
+  expect(outString).toMatch('command test args');
+});
+
+it('returns a rejected promise if ignoreReturnCode is not set with an error exit code', async () => {
+  mocks.setLog(() => {});
+  mocks.mock({ command: 'command', exitCode: 2 });
+  await expect(exec.exec('command', ['test'])).rejects.toEqual(2);
+});
+
+it('includes process.env.EXEC_MOCKS on load', async () => {
+  mocks.setLog(() => {});
+  const exitCode = await exec.exec('command', ['test'], { ignoreReturnCode: true });
+  expect(exitCode).toEqual(0);
+});
+
+it('returns a failure exit code if a command isn\'t mocked', async () => {
+  mocks.setLog(() => {});
+  mocks.clear();
+  await expect(exec.exec('command', ['test'])).rejects.toEqual(1);
+});
+
+describe('mock', () => {
+  beforeEach(() => {
+    outString = '';
+    mocks.setLog(data => outString += data);
+  });
+
+  it('prepends a command to be mocked', async () => {
+    mocks.mock({ command: 'command', exitCode: 0 });
+    const exitCode = await exec.exec('command', ['test']);
+    expect(exitCode).toEqual(0);
+  });
+
+  it('prepends an array of commands to be mocked', async () => {
+    mocks.mock([
+        { command: 'command1', exitCode: 0 },
+        { command: 'command2', exitCode: 10 }
+    ]);
+    let exitCode = await exec.exec('command1', ['test']);
+    expect(exitCode).toEqual(0);
+
+    exitCode = await exec.exec('command2', [], { ignoreReturnCode: true });
+    expect(exitCode).toEqual(10);
+  });
+
+  it('writes mock stdout', async () => {
+    const options = {
+      listeners: {
+        stdout: data => outString += data.toString()
+      },
+      outStream: new stream.Writable({ write: data => outString += data })
+    };
+
+    mocks.mock({ command: 'command', stdout: 'test out', exitCode: 0 });
+
+    await exec.exec('command', ['test'], options);
+    expect(outString).toMatch('test out');
+  });
+
+  it('writes mock stderr', async () => {
+    const options = {
+      listeners: {
+        stderr: data => outString += data.toString()
+      },
+      // prevent non stderr output from being logged
+      outStream: new stream.Writable({ write: () => {}}),
+      errStream: new stream.Writable({ write: data => outString += data })
+    };
+
+    // prevent non stderr output from being logged
+    mocks.setLog(() => {});
+    mocks.mock({ command: 'command', stderr: 'test out', exitCode: 0 });
+
+    await exec.exec('command', ['test'], options);
+    expect(outString).toMatch('test out');
+  });
+
+  it('sets a count of times the mock should trigger', async () => {
+    mocks.mock([
+      { command: 'command', exitCode: 1, count: 1},
+      { command: 'command', exitCode: 2 }
+    ]);
+
+    let exitCode = await exec.exec('command', [], { ignoreReturnCode: true });
+    expect(exitCode).toEqual(1);
+
+    exitCode = await exec.exec('command', [], { ignoreReturnCode: true });
+    expect(exitCode).toEqual(2);
+  });
+});
+
+describe('clear', () => {
+  beforeEach(() => {
+    mocks.setLog(() => {});
+  });
+
+  it('clears the known mocks', async () => {
+    mocks.mock({ command: '', exitCode: 0 });
+    mocks.clear();
+
+    const exitCode = await exec.exec('command', [], { ignoreReturnCode: true });
+    expect(exitCode).not.toEqual(0);
+  });
+});
+
+describe('restore', () => {
+  beforeEach(() => {
+    outString = '';
+    sinon.stub(console, 'log').callsFake(data => outString += data);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('resets mocks and settings to their initial states', async () => {
+    let fakeLog = '';
+    const fake = sinon.fake(log => fakeLog += log);
+
+    mocks.mock({ command: '', exitCode: 1 });
+    mocks.setLog(fake);
+    mocks.restore();
+
+    const exitCode = await exec.exec('command');
+    expect(exitCode).not.toEqual(1);
+    expect(fakeLog).toEqual('');
+    expect(fake.callCount).toEqual(0);
+    expect(outString).toMatch('command');
+  });
+});
+
+describe('setLog', () => {
+  let fake;
+  beforeEach(() => {
+    fake = sinon.fake(log => outString += log);
+    mocks.setLog(fake);
+  });
+
+  it('sets the method used to log output', async () => {
+    await exec.exec('command');
+    expect(outString).toMatch('command');
+    expect(fake.callCount).toEqual(1);
+  });
+});

--- a/test/mocks/github.test.js
+++ b/test/mocks/github.test.js
@@ -1,0 +1,159 @@
+// default state of mocks when module is loaded
+process.env.GITHUB_MOCKS = JSON.stringify([
+  { method: 'GET', uri: '', responseCode: 200 }
+])
+
+const github = require('@actions/github');
+const mocks = require('../../lib/mocks/github');
+const sinon = require('sinon');
+const path = require('path');
+
+const octokit = new github.GitHub('token');
+
+let outString;
+
+afterEach(() => {
+  mocks.restore();
+});
+
+it('uses the first found mock', async () => {
+  mocks.setLog(() => {});
+  mocks.mock([
+    { method: 'GET', uri: '', responseCode: 400 },
+    { method: 'GET', uri: '', responseCode: 500 }
+  ]);
+
+  await expect(octokit.issues.list()).rejects.toHaveProperty('status', 400);
+});
+
+it('logs the mocked request', async () => {
+  outString = '';
+  mocks.setLog(data => outString += data);
+
+  await octokit.issues.list();
+  expect(outString).toMatch('GET /issues');
+});
+
+it('returns a rejected promise if the response code is not successful', async () => {
+  mocks.setLog(() => {});
+  mocks.mock({ method: 'GET', uri: '', responseCode: 404 });
+  await expect(octokit.issues.list()).rejects.toHaveProperty('status', 404);
+});
+
+it('includes process.env.GITHUB_MOCKS on load', async () => {
+  mocks.setLog(() => {});
+  const { status } = await octokit.issues.list();
+  expect(status).toEqual(200);
+});
+
+it('returns 404 if a route isn\'t mocked', async () => {
+  mocks.setLog(() => {});
+  mocks.clear();
+  await expect(octokit.issues.list()).rejects.toHaveProperty('status', 404);
+});
+
+describe('mock', () => {
+  beforeEach(() => {
+    outString = '';
+    mocks.setLog(data => outString += data);
+  });
+
+  it('prepends a command to be mocked', async () => {
+    mocks.mock({ method: 'GET', uri: '/issues', responseCode: 202 });
+    const { status } = await octokit.issues.list();
+    expect(status).toEqual(202);
+  });
+
+  it('prepends an array of commands to be mocked', async () => {
+    mocks.mock([
+      { method: 'GET', uri: '/issues', responseCode: 201 },
+      { method: 'GET', uri: '/users', responseCode: 202 }
+    ]);
+    let { status } = await octokit.issues.list();
+    expect(status).toEqual(201);
+
+    status = (await octokit.users.list()).status;
+    expect(status).toEqual(202);
+  });
+
+  it('sends a mock string response', async () => {
+    mocks.mock({ method: 'GET', uri: '', response: 'response' });
+
+    const { data } = await octokit.issues.list();
+    expect(data).toMatch('response');
+  });
+
+  it('sends a mock response loaded from a fixture', async () => {
+    const fixture = path.normalize(path.join(__dirname, '..', 'fixtures', 'repos.json'));
+    mocks.mock({ method: 'GET', uri: '', responseFixture: fixture });
+
+    const { data } = await octokit.issues.list();
+    expect(data).toEqual(require(fixture));
+  });
+
+  it('sets a count of times the mock should trigger', async () => {
+    mocks.mock([
+      { method: 'GET', uri: '', responseCode: 201, count: 1 },
+      { method: 'GET', uri: '', responseCode: 202 }
+    ]);
+
+    let { status } = await octokit.issues.list();
+    expect(status).toEqual(201);
+
+    status = (await octokit.issues.list()).status;
+    expect(status).toEqual(202);
+  });
+});
+
+describe('clear', () => {
+  beforeEach(() => {
+    mocks.setLog(() => {});
+  });
+
+  it('clears the known mocks', async () => {
+    mocks.mock({ method: 'GET', uri: '', responseCode: 200 });
+    mocks.clear();
+
+    await expect(octokit.issues.list()).rejects.toHaveProperty('status', 404);
+  });
+});
+
+describe('restore', () => {
+  beforeEach(() => {
+    outString = '';
+    sinon.stub(console, 'log').callsFake(data => outString += data);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('resets mocks and settings to their initial states', async () => {
+    let fakeLog = '';
+    const fake = sinon.fake(log => fakeLog += log);
+
+    mocks.mock({ method: 'GET', uri: '', responseCode: 400 });
+    mocks.setLog(fake);
+    mocks.restore();
+
+    const { status } = await octokit.issues.list();
+    expect(status).not.toEqual(400);
+    expect(fakeLog).toEqual('');
+    expect(fake.callCount).toEqual(0);
+    expect(outString).toMatch('GET /issues');
+  });
+});
+
+describe('setLog', () => {
+  let fake;
+  beforeEach(() => {
+    fake = sinon.fake(log => outString += log);
+    mocks.setLog(fake);
+  });
+
+  it('sets the method used to log output', async () => {
+    await octokit.issues.list();
+    expect(outString).toMatch('GET /issues');
+    expect(fake.callCount).toEqual(1);
+  });
+});

--- a/test/runner.test.js
+++ b/test/runner.test.js
@@ -1,4 +1,4 @@
-const { run } = require('../index');
+const run = require('../lib/runner');
 const path = require('path');
 
 describe('run', () => {


### PR DESCRIPTION
This PR updates the mocking framework significantly
1. mocks are now usable in unit testing
   - each mock type responds to `mock`, `setLog`, `clear` and `restore`.  See the readme for details
   - by default, when mock types are loaded they are filled by `process.env.<MOCK TYPE>_MOCKS`, which retains the legacy functionality of using the library for end-to-end testing of an actions script
2. `@actions/exec` mocks can now print output to stdout and stderr using their respective properties on each configured mock
3. mocks can be configured to be temporary using the new `count` property.