### PR TITLE
add headers and file support for github mocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ All mock classes are enabled by default to provide a safe environment to run act
 
 ```javascript
 mocks.exec = [{ command: 'git commit', exitCode: 1 }]
-mocks.github = [{ method: 'GET', uri: '/issues', response: 200 }]
+mocks.github = [{ method: 'GET', uri: '/issues', code: 200 }]
 ```
 
 `run` returns an object `{ out, err, status }`.
@@ -79,7 +79,7 @@ expect(output).toMatch('git add');
 // myLib.listIssues calls `octokit.issues.list()`
 output = '';
 mocks.github.setLog(log => output += log + os.EOL);
-mocks.github.mock({ method: 'GET', uri: '/issues', response: '[]', responseCode: 200 });
+mocks.github.mock({ method: 'GET', uri: '/issues', response: '[]', code: 200 });
 
 const { data, status } = await myLib.listIssues();
 expect(status).toEqual(200);
@@ -145,7 +145,7 @@ The `@actions/github` mock uses `nock` to catch all calls to `https://api.github
 2. returns a response
    1. status
       - calls that don't match any configured mocks will return a `404`
-      - calls that match a configured mock will return `responseCode`, or `200` if not set
+      - calls that match a configured mock will return `code`, or `200` if not set
    2. data
       - response data can be specified when configuring a mock using the `response` property
       - response data can be loaded from a fixture by using the `responseFixture` property
@@ -167,11 +167,19 @@ To configure the mock behavior, pass an array of objects with the following form
   // Uses String.prototype.match to perform regex evaluation
   uri: '/user/repos',
   // (optional) http code to set on the response, default: 200
+  code: 200,
+  // (DEPRECATED) Please use `code` to specify a response http code
+  // (optional) http code to set on the response, default: 200
   responseCode: 200,
   // (optional) response to send, given as a string
   response: '[]',
+  // (optional) path to load response contents from
+  file: 'path/to/file',
+  // (DEPRECATED) Please use `file` to load response contents from a file, along with headers `content-type` = `application/json`
   // (optional) response to send, given as a path to a JSON fixture to load
   responseFixture: '',
+  // (optional) headers to set on the mocked response
+  headers: {},
   // (optional) number of times the mock should be used.  defaults to a persistent mock if not set
   count: 1
 }
@@ -181,7 +189,7 @@ Command patterns are prioritized based on their location in the passed in array.
 
 ```javascript
 // `GET /user/repos` will return a 400
-{ method: 'GET', uri: '/user/repos', responseCode: 400 },
+{ method: 'GET', uri: '/user/repos', code: 400 },
 // all other `GET` commands will return 500
-{ method: 'GET', uri: '', responseCode: 500 }
+{ method: 'GET', uri: '', code: 500 }
 ```

--- a/lib/mocks/github.js
+++ b/lib/mocks/github.js
@@ -1,3 +1,4 @@
+const fs = require('fs');
 const nock = require('nock');
 
 const mocks = [];
@@ -19,6 +20,8 @@ function responseFunction(uri, requestBody) {
     response = mock.response;
   } else if (mock.responseFixture) {
     response = require(mock.responseFixture);
+  } else if (mock.file) {
+    response = fs.createReadStream(mock.file);
   }
 
   if (mock.count > 0) {

--- a/lib/mocks/github.js
+++ b/lib/mocks/github.js
@@ -14,7 +14,7 @@ function responseFunction(uri, requestBody) {
     return [404, 'Route not mocked'];
   }
 
-  const responseCode = mock.responseCode || 200;
+  const responseCode = mock.code || mock.responseCode || 200;
   let response = '';
   if (mock.response) {
     response = mock.response;

--- a/lib/mocks/github.js
+++ b/lib/mocks/github.js
@@ -32,7 +32,8 @@ function responseFunction(uri, requestBody) {
     }
   }
 
-  return [responseCode, response];
+  const headers = mock.headers || {};
+  return [responseCode, response, headers];
 }
 
 // gatekeep this thing - don't let any requests get through

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "actions-mocks",
+  "name": "@jonabc/actions-mocks",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/test/mocks/github.test.js
+++ b/test/mocks/github.test.js
@@ -91,6 +91,16 @@ describe('mock', () => {
     expect(data).toEqual(require(fixture));
   });
 
+  it('sends a mock response loaded from a file', async () => {
+    const fixture = path.normalize(path.join(__dirname, '..', 'fixtures', 'repos.json'));
+    mocks.mock({ method: 'GET', uri: '', file: fixture });
+
+    const { data } = await octokit.issues.list();
+    // note that because the content-type header wasn't mocked,
+    // the data is returned as a string
+    expect(JSON.parse(data)).toEqual(require(fixture));
+  });
+
   it('sets a count of times the mock should trigger', async () => {
     mocks.mock([
       { method: 'GET', uri: '', responseCode: 201, count: 1 },

--- a/test/mocks/github.test.js
+++ b/test/mocks/github.test.js
@@ -101,6 +101,17 @@ describe('mock', () => {
     expect(JSON.parse(data)).toEqual(require(fixture));
   });
 
+  it('sends headers with the mock response', async () => {
+    const fixture = path.normalize(path.join(__dirname, '..', 'fixtures', 'repos.json'));
+    mocks.mock({ method: 'GET', uri: '', file: fixture, headers: { 'content-type': 'application/json' } });
+
+    const { data, headers } = await octokit.issues.list();
+    expect(headers).toEqual({ 'content-type': 'application/json' });
+
+    // with the proper content type set, this is returned as a json object
+    expect(data).toEqual(require(fixture));
+  });
+
   it('sets a count of times the mock should trigger', async () => {
     mocks.mock([
       { method: 'GET', uri: '', responseCode: 201, count: 1 },

--- a/test/mocks/github.test.js
+++ b/test/mocks/github.test.js
@@ -1,6 +1,6 @@
 // default state of mocks when module is loaded
 process.env.GITHUB_MOCKS = JSON.stringify([
-  { method: 'GET', uri: '', responseCode: 200 }
+  { method: 'GET', uri: '', code: 200 }
 ])
 
 const github = require('@actions/github');
@@ -19,8 +19,8 @@ afterEach(() => {
 it('uses the first found mock', async () => {
   mocks.setLog(() => {});
   mocks.mock([
-    { method: 'GET', uri: '', responseCode: 400 },
-    { method: 'GET', uri: '', responseCode: 500 }
+    { method: 'GET', uri: '', code: 400 },
+    { method: 'GET', uri: '', code: 500 }
   ]);
 
   await expect(octokit.issues.list()).rejects.toHaveProperty('status', 400);
@@ -36,7 +36,7 @@ it('logs the mocked request', async () => {
 
 it('returns a rejected promise if the response code is not successful', async () => {
   mocks.setLog(() => {});
-  mocks.mock({ method: 'GET', uri: '', responseCode: 404 });
+  mocks.mock({ method: 'GET', uri: '', code: 404 });
   await expect(octokit.issues.list()).rejects.toHaveProperty('status', 404);
 });
 
@@ -59,15 +59,15 @@ describe('mock', () => {
   });
 
   it('prepends a command to be mocked', async () => {
-    mocks.mock({ method: 'GET', uri: '/issues', responseCode: 202 });
+    mocks.mock({ method: 'GET', uri: '/issues', code: 202 });
     const { status } = await octokit.issues.list();
     expect(status).toEqual(202);
   });
 
   it('prepends an array of commands to be mocked', async () => {
     mocks.mock([
-      { method: 'GET', uri: '/issues', responseCode: 201 },
-      { method: 'GET', uri: '/users', responseCode: 202 }
+      { method: 'GET', uri: '/issues', code: 201 },
+      { method: 'GET', uri: '/users', code: 202 }
     ]);
     let { status } = await octokit.issues.list();
     expect(status).toEqual(201);
@@ -114,8 +114,8 @@ describe('mock', () => {
 
   it('sets a count of times the mock should trigger', async () => {
     mocks.mock([
-      { method: 'GET', uri: '', responseCode: 201, count: 1 },
-      { method: 'GET', uri: '', responseCode: 202 }
+      { method: 'GET', uri: '', code: 201, count: 1 },
+      { method: 'GET', uri: '', code: 202 }
     ]);
 
     let { status } = await octokit.issues.list();
@@ -132,7 +132,7 @@ describe('clear', () => {
   });
 
   it('clears the known mocks', async () => {
-    mocks.mock({ method: 'GET', uri: '', responseCode: 200 });
+    mocks.mock({ method: 'GET', uri: '', code: 200 });
     mocks.clear();
 
     await expect(octokit.issues.list()).rejects.toHaveProperty('status', 404);
@@ -153,7 +153,7 @@ describe('restore', () => {
     let fakeLog = '';
     const fake = sinon.fake(log => fakeLog += log);
 
-    mocks.mock({ method: 'GET', uri: '', responseCode: 400 });
+    mocks.mock({ method: 'GET', uri: '', code: 400 });
     mocks.setLog(fake);
     mocks.restore();
 


### PR DESCRIPTION
This PR adds `headers` and `file` as options to the GitHub API mock configuration.  They work as you'd expect, sending the headers, and file contents, back with the response, respectively.

With this change I've also added a new `code` argument, which is a long term replacement for `responseCode`.

`responseCode` is deprecated by `code`.
`responseFixture` is deprecated by `file: fixturePath` + `headers: { 'content-type': 'application/json' }`