### PR TITLE
Raise on exec failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,10 +100,10 @@ The `@actions/exec` mock catches all calls to `@actions/exec.exec` and
 2. output provided `stdout` using the passed in options
 3. output provided `stderr` using the passed in options
 4. return an exit code
-   - if the command doesn't match a configured mock, returns 127
-   - if the command matches a configured mock, returns the configured `exitCode` or 0 if not set
+   - if the command doesn't match a configured mock, rejects with an error for exit code 127
+   - if the command matches a configured mock, resolves to the configured `exitCode` if 0 or rejects with an error for non-0 values
 
-The mocked call returns a promise that is resolved for a 0 exit code and rejected for all other exit codes.  Calls to `@actions/exec.exec` that specify `options: { ignoreReturnCode: true }` will never be rejected.
+The mocked call returns a promise that is resolved for a 0 exit code and rejected with an error for all other exit codes.  Calls to `@actions/exec.exec` that specify `options: { ignoreReturnCode: true }` will never be rejected.
 
 ```javascript
 // with a resolved mocked command

--- a/lib/mocks/exec.js
+++ b/lib/mocks/exec.js
@@ -48,7 +48,7 @@ sinon.stub(exec, 'exec').callsFake(async (command, args = [], options = {}) => {
   }
 
   if (exitCode !== 0 && !options.ignoreReturnCode) {
-    return Promise.reject(exitCode);
+    return Promise.reject(new Error(`Failed with exit code ${exitCode}`));
   }
 
   return Promise.resolve(exitCode);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@jonabc/actions-mocks",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1207,9 +1207,9 @@
       }
     },
     "commander": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true,
       "optional": true
     },
@@ -2629,9 +2629,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.3.1.tgz",
-      "integrity": "sha512-c0HoNHzDiHpBt4Kqe99N8tdLPKAnGCQ73gYMPWtAYM4PwGnf7xl8PBUHJqh9ijlzt2uQKaSRxbXRt+rZ7M2/kA==",
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.2.tgz",
+      "integrity": "sha512-4PwqDL2laXtTWZghzzCtunQUTLbo31pcCJrd/B/9JP8XbhVzpS5ZXuKqlOzsd1rtcaLo4KqAn8nl8mkknS4MHw==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -5383,13 +5383,13 @@
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
     },
     "uglify-js": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
-      "integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
+      "version": "3.7.5",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.5.tgz",
+      "integrity": "sha512-GFZ3EXRptKGvb/C1Sq6nO1iI7AGcjyqmIyOw0DrD0675e+NNbGO72xmMM2iEBdFbxaTLo70NbjM/Wy54uZIlsg==",
       "dev": true,
       "optional": true,
       "requires": {
-        "commander": "~2.20.0",
+        "commander": "~2.20.3",
         "source-map": "~0.6.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jonabc/actions-mocks",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Mocks and utilities to help when testing GitHub Actions",
   "main": "index.js",
   "directories": {

--- a/test/mocks/exec.test.js
+++ b/test/mocks/exec.test.js
@@ -37,7 +37,9 @@ it('logs the mocked command', async () => {
 it('returns a rejected promise if ignoreReturnCode is not set with an error exit code', async () => {
   mocks.setLog(() => {});
   mocks.mock({ command: 'command', exitCode: 2 });
-  await expect(exec.exec('command', ['test'])).rejects.toEqual(2);
+  await expect(exec.exec('command', ['test'])).rejects.toThrow(
+    'Failed with exit code 2'
+  );
 });
 
 it('includes process.env.EXEC_MOCKS on load', async () => {
@@ -49,7 +51,9 @@ it('includes process.env.EXEC_MOCKS on load', async () => {
 it('returns a failure exit code if a command isn\'t mocked', async () => {
   mocks.setLog(() => {});
   mocks.clear();
-  await expect(exec.exec('command', ['test'])).rejects.toEqual(127);
+  await expect(exec.exec('command', ['test'])).rejects.toThrow(
+    'Failed with exit code 127'
+  );
 });
 
 describe('mock', () => {

--- a/test/runner.test.js
+++ b/test/runner.test.js
@@ -23,7 +23,7 @@ describe('run', () => {
     expect(out).toMatch('test-not-mocked exited with status 1');
 
     expect(out).toMatch('test-not-ignored');
-    expect(out).toMatch('test-not-ignored caught with status 3');
+    expect(out).toMatch('test-not-ignored caught with status Error: Failed with exit code 3');
   });
 
 


### PR DESCRIPTION
The previous behavior to reject with the raw exit code is inconsistent with `@actions/exec` functionality, which raises an error with the exit code when the exit code isn't ignored.

This is a small, potentially breaking change that fixes the behavior, though I opted to bump the patch release number rather than move to a 2.x.x release due to what looks to be low usage and a preference to reserve major version number updates to more significant changes.